### PR TITLE
Update to latest official serverless-http

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,4 +3,4 @@
 
 import { Server } from "restify";
 
-export function serverless(app: Server): (event: AWSLambda.APIGatewayEvent, context: AWSLambda.Context, callback: AWSLambda.ProxyCallback) => void;
+export function serverless(app: Server, opts: Object): (event: AWSLambda.APIGatewayEvent, context: AWSLambda.Context, callback: AWSLambda.ProxyCallback) => void;

--- a/index.js
+++ b/index.js
@@ -9,12 +9,12 @@ patchRequest(SlsHttpRequest);
 patchResponse(SlsHttpResponse);
 
 module.exports = {
-    serverless: function (app) {
+    serverless: function (app, opts = {}) {
         const handler = (req, res) => {
             _.get(app, '_setupRequest').call(app, req, res);
             _.get(app, '_handle').call(app, req, res);
         };
 
-        return slsHttp(handler);
+        return slsHttp(handler, opts);
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -530,6 +530,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
+    "serverless-http": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-1.8.0.tgz",
+      "integrity": "sha512-zLQp6iPvnJUPQ7r7rqSUQEoeK/1FQnS/4KYpP/lMcgbvIv1nOf+3mQn+ATUUz0Sjh4991oug7tnHjaDp/xWcdQ=="
+    },
     "spdy": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "restify": "^6.3.4",
-    "serverless-http": "git+https://github.com/drudderd/serverless-http.git"
+    "serverless-http": "^1.8.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "0.0.30",


### PR DESCRIPTION
[serverless-http](
https://github.com/dougmoscrop/serverless-http) includes a fix for your _body => __body change. Bring dependency back to upstream and update function call to match [serverless-http](
https://github.com/dougmoscrop/serverless-http).